### PR TITLE
fix: blocks travelled not being counted correctly

### DIFF
--- a/src/main/java/com/songoda/epicautomators/task/projectile/Projectile.java
+++ b/src/main/java/com/songoda/epicautomators/task/projectile/Projectile.java
@@ -77,8 +77,7 @@ public class Projectile {
 
             boolean isNotCrop = !isCrop(block) || isCropFullyGrown(block);
 
-            if (isNotCrop)
-                blocksTravelled++;
+            blocksTravelled++;
 
             if (blocksTravelled % 5 == 0)
                 nearbyEntities = location.getWorld().getNearbyEntities(location, 100, 100, 100);


### PR DESCRIPTION
The block counter wasn't going up because a check was being performed to check if a block is a crop or not, the block counter should be incremented in any case, if it is a crop or not, the projectile has travelled over the block.